### PR TITLE
Add initial unit tests and CI pipeline

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,57 @@
+name: Bug Report
+description: File a bug report
+labels: ["Type: Bug", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
+        sure you are using the latest version of the charm. If not, please switch to this image prior to 
+        posting your report to make sure it's not already solved.
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: >
+        If applicable, add screenshots to help explain your problem. If applicable, add screenshots to 
+        help explain the problem you are facing.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: >
+        Please provide a step-by-step instruction of how to reproduce the behavior.
+      placeholder: |
+        1. `juju deploy ...`
+        2. `juju relate ...`
+        3. `juju status --relations`
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        We need to know a bit more about the context in which you run the charm.
+        - Are you running Juju locally, on lxd, in multipass or on some other platform?
+        - What track and channel you deployed the charm from (ie. `latest/edge` or similar).
+        - Version of any applicable components, like the juju snap, the model controller, lxd, microk8s, and/or multipass.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: >
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs 
+        at https://juju.is/docs/olm/juju-logs
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -6,8 +6,8 @@ body:
     attributes:
       value: >
         Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
-        sure you are using the latest version of the charm. If not, please switch to this image prior to 
-        posting your report to make sure it's not already solved.
+        sure you are using the latest version of the charm. If not, please switch to the lastest version of this charm
+        before posting your report to make sure it's not already solved.
   - type: textarea
     id: bug-description
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,8 +13,7 @@ body:
     attributes:
       label: Bug Description
       description: >
-        If applicable, add screenshots to help explain your problem. If applicable, add screenshots to 
-        help explain the problem you are facing.
+        Provide a description of the issue you are facing. If applicable, add screenshots to help explain the problem.
     validations:
       required: true
   - type: textarea
@@ -46,8 +45,8 @@ body:
       label: Relevant log output
       description: >
         Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
-        Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs 
-        at https://juju.is/docs/olm/juju-logs
+        Fetch the logs using `juju debug-log --replay`. Additional details available in the juju docs at
+        https://juju.is/docs/olm/juju-logs
       render: shell
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
@@ -1,0 +1,17 @@
+name: Enhancement Proposal
+description: File an enhancement proposal
+labels: ["Type: Enhancement", "Status: Triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this enhancement proposal! Before submitting your issue, please make
+        sure there isn't already a prior issue concerning this. If there is, please join that discussion instead.
+  - type: textarea
+    id: enhancement-proposal
+    attributes:
+      label: Enhancement Proposal
+      description: >
+        Describe the enhancement you would like to see in as much detail as needed.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.yml
@@ -5,8 +5,8 @@ body:
   - type: markdown
     attributes:
       value: >
-        Thanks for taking the time to fill out this enhancement proposal! Before submitting your issue, please make
-        sure there isn't already a prior issue concerning this. If there is, please join that discussion instead.
+        Thanks for taking the time to fill out this enhancement proposal! Before submitting your proposal, please make
+        sure there isn't a pre-existing similar proposal. If there is, please join that discussion instead.
   - type: textarea
     id: enhancement-proposal
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,10 @@ motivation and context. Is it a new feature? A bug fix? Does it address an exist
 ## How was the code tested?
 
 > Describe the conditions under which the code has been tested.
+> * Did you run the defined integration and units under `tests/`?
+> * Did you write new tests? Where are they located in the repository?
+> * Which undercloud did you use to perform the tests? LXD, vSphere, AWS, etc.
+> * What operating system did you test the charms on? Ubuntu 22.04, Ubuntu 20.04, CentOS 7, etc.
 
 ## Related issues and/or tasks
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Description
+
+> Provide a description of the purpose of this pull request, as well as its
+motivation and context. Is it a new feature? A bug fix? Does it address an existing issue?
+
+## How was the code tested?
+
+> Describe the conditions under which the code has been tested.
+
+## Related issues and/or tasks
+
+> Link any related issues or project board tasks to this pull request.
+
+## Checklist
+
+- [ ] I am the author of these changes, or I have the rights to submit them.
+- [ ] I have added the relevant changes to the README and/or documentation.
+- [ ] I have self reviewed my own code.
+- [ ] All requested changes and/or review comments have been resolved.

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,0 +1,27 @@
+name: Build/Test
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run linters
+        run: tox -e lint
+
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: python3 -m pip install tox
+      - name: Run tests
+        run: tox -e unit

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -25,3 +25,16 @@ jobs:
         run: python3 -m pip install tox
       - name: Run tests
         run: tox -e unit
+
+  call-inclusive-naming-check:
+      name: Inclusive naming
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: woke
+          uses: get-woke/woke-action@v0
+          with:
+            # Cause the check to fail on any broke rules
+            fail-on-error: true

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -4,6 +4,19 @@ on:
   workflow_call:
 
 jobs:
+  inclusive-naming-check:
+    name: Inclusive naming check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          # Cause the check to fail on any broke rules
+          fail-on-error: true
+
   lint:
     name: Lint
     runs-on: ubuntu-22.04
@@ -25,16 +38,3 @@ jobs:
         run: python3 -m pip install tox
       - name: Run tests
         run: tox -e unit
-
-  call-inclusive-naming-check:
-      name: Inclusive naming
-      runs-on: ubuntu-latest
-      steps:
-        - name: Checkout
-          uses: actions/checkout@v2
-
-        - name: woke
-          uses: get-woke/woke-action@v0
-          with:
-            # Cause the check to fail on any broke rules
-            fail-on-error: true

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,0 +1,9 @@
+name: Tests
+on:
+  pull_request:
+    paths-ignore:
+      - ".gitignore"
+
+jobs:
+  test:
+    uses: ./.github/workflows/build-and-test.yaml

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Canonical Ltd.
+   Copyright 2023 Canonical Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Canonical Ltd.
+   Copyright 2023 Omnivector, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,20 +14,26 @@ log_cli_level = "INFO"
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff]
+line-length = 99
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+extend-exclude = ["__pycache__", "*.egg_info"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
-# Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 # Testing tools configuration
 [tool.coverage.run]
 branch = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+[tool.codespell]
+skip = "./build,./lib,./venv,./icon.svg"
+
 # Testing tools configuration
 [tool.coverage.run]
 branch = true
@@ -26,17 +29,14 @@ extend-ignore = [
     "D204",
     "D213",
     "D215",
-    "D400",
-    "D404",
     "D406",
     "D407",
     "D408",
     "D409",
     "D413",
 ]
-ignore = ["E501", "D107"]
+ignore = ["E501"]
 extend-exclude = ["__pycache__", "*.egg_info"]
-per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.ruff.mccabe]
 max-complexity = 10

--- a/src/interface_slurmd.py
+++ b/src/interface_slurmd.py
@@ -4,7 +4,11 @@ import json
 import logging
 
 from ops.framework import (
-    EventBase, EventSource, Object, ObjectEvents, StoredState,
+    EventBase,
+    EventSource,
+    Object,
+    ObjectEvents,
+    StoredState,
 )
 from ops.model import Relation
 from utils import get_inventory
@@ -45,7 +49,7 @@ class Slurmd(Object):
             slurmctld_addr=str(),
             slurmctld_port=str(),
             etcd_port=str(),
-            nhc_params=str()
+            nhc_params=str(),
         )
 
         self.framework.observe(
@@ -100,9 +104,9 @@ class Slurmd(Object):
         # at this point so retrieve them from the relation data and store
         # them in the charm's stored state.
         self._store_munge_key(app_data["munge_key"])
-        self._store_slurmctld_host_port(app_data["slurmctld_host"],
-                                        app_data["slurmctld_port"],
-                                        slurmctld_addr)
+        self._store_slurmctld_host_port(
+            app_data["slurmctld_host"], app_data["slurmctld_port"], slurmctld_addr
+        )
         self.etcd_port = app_data["etcd_port"]
 
         self._charm.cluster_name = app_data.get("cluster_name")
@@ -121,7 +125,6 @@ class Slurmd(Object):
         - nhc parameters changed
         - tls parameters changed
         """
-
         app_data = event.relation.data[event.app]
         self._store_nhc_params(app_data.get("nhc_params"))
         self._store_tls_params(app_data.get("tls_cert"), app_data.get("ca_cert"))
@@ -173,9 +176,7 @@ class Slurmd(Object):
         # there is only one slurmctld, so there should be only one relation here
         relations = self._charm.framework.model.relations["slurmd"]
         for relation in relations:
-            relation.data[self.model.app]["partition_info"] = json.dumps(
-                partition_info
-            )
+            relation.data[self.model.app]["partition_info"] = json.dumps(partition_info)
 
     def _store_munge_key(self, munge_key: str):
         """Store the munge_key in the StoredState."""

--- a/src/omnietcd3.py
+++ b/src/omnietcd3.py
@@ -11,18 +11,31 @@ logger = logging.getLogger(__name__)
 
 class Etcd3AuthClient(Etcd3Client):
     """Handle etcd3 requests with auth."""
-    def __init__(self, host='localhost', port=2379, protocol="http",
-                 ca_cert=None, cert_key=None, cert_cert=None, timeout=None,
-                 username=None, password=None, api_path="/v3/"):
+
+    def __init__(
+        self,
+        host="localhost",
+        port=2379,
+        protocol="http",
+        ca_cert=None,
+        cert_key=None,
+        cert_cert=None,
+        timeout=None,
+        username=None,
+        password=None,
+        api_path="/v3/",
+    ):
         """Initialize class."""
-        super(Etcd3AuthClient, self).__init__(host=host,
-                                              port=port,
-                                              protocol=protocol,
-                                              ca_cert=ca_cert,
-                                              cert_key=cert_key,
-                                              cert_cert=cert_cert,
-                                              timeout=timeout,
-                                              api_path=api_path)
+        super(Etcd3AuthClient, self).__init__(
+            host=host,
+            port=port,
+            protocol=protocol,
+            ca_cert=ca_cert,
+            cert_key=cert_key,
+            cert_cert=cert_cert,
+            timeout=timeout,
+            api_path=api_path,
+        )
         self.username = username
         self.password = password
 
@@ -32,16 +45,16 @@ class Etcd3AuthClient(Etcd3Client):
         # header with an old token, or else etcd responds with
         # "Unauthorized: invalid auth token".  So remove any existing
         # Authorization header.
-        if 'Authorization' in self.session.headers:
-            del self.session.headers['Authorization']
+        if "Authorization" in self.session.headers:
+            del self.session.headers["Authorization"]
 
         # Send authenticate request.  If this raises an exception,
         # e.g. because of a connectivity issue to the etcd server,
         # it's OK for that to bubble up and be handled in the code
         # that called post.
         response = super(Etcd3AuthClient, self).post(
-            self.get_url('/auth/authenticate'),
-            json={"name": self.username, "password": self.password}
+            self.get_url("/auth/authenticate"),
+            json={"name": self.username, "password": self.password},
         )
 
         # Add Authorization header with the received token to the
@@ -50,7 +63,7 @@ class Etcd3AuthClient(Etcd3Client):
         # the watch code does not use client.post and so could not be
         # covered by adding a header to kwargs in the following post
         # method.
-        self.session.headers['Authorization'] = response['token']
+        self.session.headers["Authorization"] = response["token"]
 
     def post(self, *args, **kwargs):
         """Wrap the internal post function with authentication."""
@@ -64,8 +77,7 @@ class Etcd3AuthClient(Etcd3Client):
                 # Etcd auth credentials are configured, so assume the
                 # problem might be that we need to authenticate or
                 # re-authenticate.
-                logger.info("## etcd: Might need to (re)authenticate: %r:\n%s",
-                            e, e.detail_text)
+                logger.info("## etcd: Might need to (re)authenticate: %r:\n%s", e, e.detail_text)
 
                 # Authenticate and then reissue the request.
                 self.authenticate()

--- a/src/utils.py
+++ b/src/utils.py
@@ -21,8 +21,7 @@ def lscpu():
     lscpu_lines = lscpu_out.decode().strip().split("\n")
 
     return {
-        format_key(line.split(":")[0].strip()): line.split(":")[1].strip()
-        for line in lscpu_lines
+        format_key(line.split(":")[0].strip()): line.split(":")[1].strip() for line in lscpu_lines
     }
 
 
@@ -44,8 +43,7 @@ def lspci_nvidia():
     try:
         gpus = int(
             subprocess.check_output(
-                "lspci | grep -i nvidia | awk '{print $1}' "
-                "| cut -d : -f 1 | sort -u | wc -l",
+                "lspci | grep -i nvidia | awk '{print $1}' " "| cut -d : -f 1 | sort -u | wc -l",
                 shell=True,
             )
             .decode()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import PropertyMock, patch
+
+from charm import SlurmdCharm
+from ops.model import ActiveStatus, BlockedStatus
+from ops.testing import Harness
+
+class TestCharm(unittest.TestCase):
+    def setUp(self) -> None:
+        self.harness = Harness(SlurmdCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.begin()
+        self.maxDiff = None
+
+    def test_update_status_fail(self):
+        self.harness.charm.on.update_status.emit()
+        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Machine needs reboot"))
+
+    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
+    @patch("interface_slurmd.Slurmd.is_joined", new_callable=PropertyMock(return_value=True))
+    @patch("slurm_ops_manager.SlurmManager.check_munged", lambda _: True)
+    def test_update_status_success(self, *_):
+        self.harness.charm._stored.slurm_installed = True
+        self.harness.charm._stored.slurmctld_available = True
+        self.harness.charm._stored.slurmctld_started = True
+
+        self.harness.charm.on.update_status.emit()
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus("slurmd available"))

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -13,7 +13,8 @@ class TestCharm(unittest.TestCase):
         self.harness.begin()
 
     @patch("ops.framework.EventBase.defer")
-    def test_check_etcd_fail(self, defer):
+    def test_check_etcd_fail(self, defer) -> None:
+        """Test check_etcd method failure behavior."""
         self.harness.charm.on.check_etcd.emit()
         defer.assert_called()
 
@@ -24,23 +25,27 @@ class TestCharm(unittest.TestCase):
     @patch("charm.SlurmdCharm.etcd_ca_cert", new_callable=PropertyMock(return_value=""))
     @patch("charm.SlurmdCharm.etcd_use_tls", new_callable=PropertyMock(return_value=False))
     @patch("ops.framework.EventBase.defer")
-    def test_check_etcd_success(self, defer, *_):
+    def test_check_etcd_success(self, defer, *_) -> None:
+        """Test check_etcd method success behavior."""
         self.harness.charm.on.check_etcd.emit()
         defer.assert_not_called()
 
     @patch("ops.framework.EventBase.defer")
-    def test_config_changed_fail(self, defer):
+    def test_config_changed_fail(self, defer) -> None:
+        """Test config_changed failure behavior."""
         self.harness.set_leader(True)
         self.harness.charm.on.config_changed.emit()
         defer.assert_called()
 
     @patch("ops.framework.EventBase.defer")
-    def test_config_changed_success(self, defer):
+    def test_config_changed_success(self, defer) -> None:
+        """Test config_changed success behavior."""
         self.harness.charm.on.config_changed.emit()
         defer.assert_not_called()
 
     @patch("ops.framework.EventBase.defer")
-    def test_install_fail(self, defer):
+    def test_install_fail(self, defer) -> None:
+        """Test install failure behavior."""
         self.harness.charm.on.install.emit()
         self.assertFalse(self.harness.charm._stored.slurm_installed)
         defer.assert_called()
@@ -50,17 +55,20 @@ class TestCharm(unittest.TestCase):
     @patch("ops.model.Unit.set_workload_version")
     @patch("ops.model.Resources.fetch")
     @patch("ops.framework.EventBase.defer")
-    def test_install_success(self, defer, *_):
+    def test_install_success(self, defer, *_) -> None:
+        """Test install success behavior."""
         self.harness.charm.on.install.emit()
         self.assertTrue(self.harness.charm._stored.slurm_installed)
         defer.assert_not_called()
 
-    def test_slurmctld_started(self):
+    def test_slurmctld_started(self) -> None:
+        """Test slurmctld_started works."""
         self.harness.charm.on.slurmctld_started.emit()
         self.assertTrue(self.harness.charm._stored.slurmctld_started)
 
     @patch("ops.framework.EventBase.defer")
-    def test_slurmd_start_fail(self, defer):
+    def test_slurmd_start_fail(self, defer) -> None:
+        """Test slurmd_start failure behavior."""
         self.harness.charm.on.slurmd_start.emit()
         defer.assert_called()
 
@@ -69,11 +77,12 @@ class TestCharm(unittest.TestCase):
         new_callable=PropertyMock(return_value=False),
     )
     @patch("interface_slurmd.Slurmd.is_joined", new_callable=PropertyMock(return_value=True))
-    @patch("slurm_ops_manager.SlurmManager.check_munged", lambda _: True)
-    @patch("slurm_ops_manager.SlurmManager.slurm_is_active", lambda _: True)
+    @patch("slurm_ops_manager.SlurmManager.check_munged", return_value=True)
+    @patch("slurm_ops_manager.SlurmManager.slurm_is_active", return_value=True)
     @patch("slurm_ops_manager.SlurmManager.slurm_systemctl", lambda *_: "stop", True)
     @patch("ops.framework.EventBase.defer")
-    def test_slurmd_start_success(self, defer, *_):
+    def test_slurmd_start_success(self, defer, *_) -> None:
+        """Test slurmd_start success behavior."""
         self.harness.charm._stored.slurm_installed = True
         self.harness.charm._stored.slurmctld_available = True
         self.harness.charm._stored.slurmctld_started = True
@@ -86,14 +95,16 @@ class TestCharm(unittest.TestCase):
         "slurm_ops_manager.SlurmManager.needs_reboot",
         new_callable=PropertyMock(return_value=False),
     )
-    def test_update_status_install_fail(self, _):
+    def test_update_status_install_fail(self, _) -> None:
+        """Test update_status failure behavior from install."""
         self.harness.charm.on.update_status.emit()
         self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Error installing slurmd"))
 
     @patch(
         "slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=True)
     )
-    def test_update_status_needs_reboot(self, _):
+    def test_update_status_needs_reboot(self, _) -> None:
+        """Test update_status failure behavior from reboot."""
         self.harness.charm.on.update_status.emit()
         self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Machine needs reboot"))
 
@@ -102,8 +113,9 @@ class TestCharm(unittest.TestCase):
         new_callable=PropertyMock(return_value=False),
     )
     @patch("interface_slurmd.Slurmd.is_joined", new_callable=PropertyMock(return_value=True))
-    @patch("slurm_ops_manager.SlurmManager.check_munged", lambda _: True)
-    def test_update_status_success(self, *_):
+    @patch("slurm_ops_manager.SlurmManager.check_munged", return_value=True)
+    def test_update_status_success(self, *_) -> None:
+        """Test update_status success behavior."""
         self.harness.charm._stored.slurm_installed = True
         self.harness.charm._stored.slurmctld_available = True
         self.harness.charm._stored.slurmctld_started = True

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,6 +5,7 @@ from charm import SlurmdCharm
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
+
 class TestCharm(unittest.TestCase):
     def setUp(self) -> None:
         self.harness = Harness(SlurmdCharm)
@@ -37,7 +38,7 @@ class TestCharm(unittest.TestCase):
     def test_config_changed_success(self, defer):
         self.harness.charm.on.config_changed.emit()
         defer.assert_not_called()
-    
+
     @patch("ops.framework.EventBase.defer")
     def test_install_fail(self, defer):
         self.harness.charm.on.install.emit()
@@ -53,17 +54,20 @@ class TestCharm(unittest.TestCase):
         self.harness.charm.on.install.emit()
         self.assertTrue(self.harness.charm._stored.slurm_installed)
         defer.assert_not_called()
-    
+
     def test_slurmctld_started(self):
         self.harness.charm.on.slurmctld_started.emit()
         self.assertTrue(self.harness.charm._stored.slurmctld_started)
-    
+
     @patch("ops.framework.EventBase.defer")
     def test_slurmd_start_fail(self, defer):
         self.harness.charm.on.slurmd_start.emit()
         defer.assert_called()
 
-    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
+    @patch(
+        "slurm_ops_manager.SlurmManager.needs_reboot",
+        new_callable=PropertyMock(return_value=False),
+    )
     @patch("interface_slurmd.Slurmd.is_joined", new_callable=PropertyMock(return_value=True))
     @patch("slurm_ops_manager.SlurmManager.check_munged", lambda _: True)
     @patch("slurm_ops_manager.SlurmManager.slurm_is_active", lambda _: True)
@@ -78,17 +82,25 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus("slurmd available"))
         defer.assert_not_called()
 
-    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
+    @patch(
+        "slurm_ops_manager.SlurmManager.needs_reboot",
+        new_callable=PropertyMock(return_value=False),
+    )
     def test_update_status_install_fail(self, _):
         self.harness.charm.on.update_status.emit()
         self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Error installing slurmd"))
 
-    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=True))
+    @patch(
+        "slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=True)
+    )
     def test_update_status_needs_reboot(self, _):
         self.harness.charm.on.update_status.emit()
         self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Machine needs reboot"))
 
-    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
+    @patch(
+        "slurm_ops_manager.SlurmManager.needs_reboot",
+        new_callable=PropertyMock(return_value=False),
+    )
     @patch("interface_slurmd.Slurmd.is_joined", new_callable=PropertyMock(return_value=True))
     @patch("slurm_ops_manager.SlurmManager.check_munged", lambda _: True)
     def test_update_status_success(self, *_):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,9 +10,81 @@ class TestCharm(unittest.TestCase):
         self.harness = Harness(SlurmdCharm)
         self.addCleanup(self.harness.cleanup)
         self.harness.begin()
-        self.maxDiff = None
 
-    def test_update_status_fail(self):
+    @patch("ops.framework.EventBase.defer")
+    def test_check_etcd_fail(self, defer):
+        self.harness.charm.on.check_etcd.emit()
+        defer.assert_called()
+
+    @patch("charm.SlurmdCharm._on_slurmctld_started")
+    @patch("json.loads", lambda _: ["test"])
+    @patch("charm.SlurmdCharm.hostname", new_callable=PropertyMock(return_value="test"))
+    @patch("omnietcd3.Etcd3AuthClient.get")
+    @patch("charm.SlurmdCharm.etcd_ca_cert", new_callable=PropertyMock(return_value=""))
+    @patch("charm.SlurmdCharm.etcd_use_tls", new_callable=PropertyMock(return_value=False))
+    @patch("ops.framework.EventBase.defer")
+    def test_check_etcd_success(self, defer, *_):
+        self.harness.charm.on.check_etcd.emit()
+        defer.assert_not_called()
+
+    @patch("ops.framework.EventBase.defer")
+    def test_config_changed_fail(self, defer):
+        self.harness.set_leader(True)
+        self.harness.charm.on.config_changed.emit()
+        defer.assert_called()
+
+    @patch("ops.framework.EventBase.defer")
+    def test_config_changed_success(self, defer):
+        self.harness.charm.on.config_changed.emit()
+        defer.assert_not_called()
+    
+    @patch("ops.framework.EventBase.defer")
+    def test_install_fail(self, defer):
+        self.harness.charm.on.install.emit()
+        self.assertFalse(self.harness.charm._stored.slurm_installed)
+        defer.assert_called()
+
+    @patch("slurm_ops_manager.SlurmManager.install")
+    @patch("pathlib.Path.read_text", return_value="v1.0.0")
+    @patch("ops.model.Unit.set_workload_version")
+    @patch("ops.model.Resources.fetch")
+    @patch("ops.framework.EventBase.defer")
+    def test_install_success(self, defer, *_):
+        self.harness.charm.on.install.emit()
+        self.assertTrue(self.harness.charm._stored.slurm_installed)
+        defer.assert_not_called()
+    
+    def test_slurmctld_started(self):
+        self.harness.charm.on.slurmctld_started.emit()
+        self.assertTrue(self.harness.charm._stored.slurmctld_started)
+    
+    @patch("ops.framework.EventBase.defer")
+    def test_slurmd_start_fail(self, defer):
+        self.harness.charm.on.slurmd_start.emit()
+        defer.assert_called()
+
+    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
+    @patch("interface_slurmd.Slurmd.is_joined", new_callable=PropertyMock(return_value=True))
+    @patch("slurm_ops_manager.SlurmManager.check_munged", lambda _: True)
+    @patch("slurm_ops_manager.SlurmManager.slurm_is_active", lambda _: True)
+    @patch("slurm_ops_manager.SlurmManager.slurm_systemctl", lambda *_: "stop", True)
+    @patch("ops.framework.EventBase.defer")
+    def test_slurmd_start_success(self, defer, *_):
+        self.harness.charm._stored.slurm_installed = True
+        self.harness.charm._stored.slurmctld_available = True
+        self.harness.charm._stored.slurmctld_started = True
+
+        self.harness.charm.on.slurmd_start.emit()
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus("slurmd available"))
+        defer.assert_not_called()
+
+    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=False))
+    def test_update_status_install_fail(self, _):
+        self.harness.charm.on.update_status.emit()
+        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Error installing slurmd"))
+
+    @patch("slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=True))
+    def test_update_status_needs_reboot(self, _):
         self.harness.charm.on.update_status.emit()
         self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Machine needs reboot"))
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,30 +24,22 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =
-    black==22.12.0
-    ruff==0.0.206
+    black
+    ruff
 commands =
-    ruff --fix {[vars]all_path}
     black {[vars]all_path}
+    ruff --fix {[vars]all_path} 
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    black==22.12.0
-    codespell==2.2.2
-    ruff==0.0.206
+    black
+    codespell
+    ruff
 commands =
-    codespell {toxinidir}/. \
-    --skip {toxinidir}/.git \
-    --skip {toxinidir}/.tox \
-    --skip {toxinidir}/build \
-    --skip {toxinidir}/lib \
-    --skip {toxinidir}/venv \
-    --skip {toxinidir}/.mypy_cache \
-    --skip {toxinidir}/icon.svg
-
-    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
+    codespell {toxinidir}
+    ruff {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests
@@ -58,8 +50,6 @@ deps =
 commands =
     coverage run --source={[vars]src_path} \
         -m pytest \
-        --ignore={[vars]tst_path}integration \
-        --ignore={[vars]tst_path}functional \
         --tb native \
         -v \
         -s \

--- a/tox.ini
+++ b/tox.ini
@@ -9,13 +9,15 @@ envlist = lint, unit
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
-;lib_path = {toxinidir}/lib/charms/operator_name_with_underscores
-all_path = {[vars]src_path} {[vars]tst_path} 
+lib_path = {toxinidir}/lib/charms/slurmd
+all_path = {[vars]src_path} {[vars]tst_path} {[vars]lib_path} 
+lxd_name = slurmd-func-test
+ftest_path = {toxinidir}/tests/functional
 
 [testenv]
 setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
-  PYTHONBREAKPOINT=pdb.set_trace
+  PYTHONBREAKPOINT=ipdb.set_trace
   PY_COLORS=1
 passenv =
   PYTHONPATH
@@ -25,50 +27,101 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =
-    black
-    isort
+    black==22.12.0
+    ruff==0.0.206
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    black
-    flake8-docstrings
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
-    codespell
+    black==22.12.0
+    codespell==2.2.2
+    ruff==0.0.206
 commands =
     # uncomment the following line if this charm owns a lib
-    # codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
-      --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    codespell {[vars]lib_path}
+    codespell {toxinidir}/. \
+    --skip {toxinidir}/.git \
+    --skip {toxinidir}/.tox \
+    --skip {toxinidir}/build \
+    --skip {toxinidir}/lib \
+    --skip {toxinidir}/venv \
+    --skip {toxinidir}/.mypy_cache \
+    --skip {toxinidir}/icon.svg
+
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests
 deps =
-    pytest
-    coverage[toml]
+    pytest==7.2.0
+    coverage[toml]==6.5.0
     -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
-        -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
+        -m pytest \
+        --ignore={[vars]tst_path}integration \
+        --ignore={[vars]tst_path}functional \
+        --tb native \
+        -v \
+        -s \
+        {posargs}
     coverage report
+
+[testenv:functional]
+description = Build a LXD container for functional tests then run the tests
+allowlist_externals = 
+    lxc
+    bash
+commands =
+    # Create a LXC container with the relevant packages installed
+    bash -c 'lxc launch -qe ubuntu:jammy {[vars]lxd_name} -c=user.user-data="$(<{[vars]ftest_path}/test_setup.yaml)"'
+    # Wait for the cloud-init process to finish
+    lxc exec {[vars]lxd_name} -- bash -c "cloud-init status -w >/dev/null 2>&1"
+    # Copy all the files needed for integration testing
+    lxc file push -qp {toxinidir}/tox.ini {[vars]lxd_name}/{[vars]lxd_name}/
+    lxc file push -qp {toxinidir}/pyproject.toml {[vars]lxd_name}/{[vars]lxd_name}/
+    lxc file push -qp {toxinidir}/config.yaml {[vars]lxd_name}/{[vars]lxd_name}/
+    lxc file push -qpr {toxinidir}/lib {[vars]lxd_name}/{[vars]lxd_name}/
+    lxc file push -qpr {toxinidir}/src {[vars]lxd_name}/{[vars]lxd_name}/
+    lxc file push -qpr {[vars]tst_path} {[vars]lxd_name}/{[vars]lxd_name}/
+    # Run the tests
+    lxc exec {[vars]lxd_name} -- tox -c /{[vars]lxd_name}/tox.ini -e functional-tests {posargs}
+commands_post =
+    -lxc stop {[vars]lxd_name}
+
+[testenv:functional-tests]
+description = Run functional tests
+deps =
+    ops==1.5.4
+    pytest==7.2.0
+commands =
+    pytest -v \
+           -s \
+           --tb native \
+           --ignore={[vars]tst_path}unit \
+           --ignore={[vars]tst_path}integration \
+           --log-cli-level=INFO \
+           {posargs}
 
 [testenv:integration]
 description = Run integration tests
 deps =
-    pytest
-    juju
-    pytest-operator
-    -r{toxinidir}/requirements.txt
+    pytest==7.2.0
+    juju==3.0.4
+    pytest-operator==0.22.0
+    requests==2.28.1
+    tenacity==8.1.0
 commands =
-    pytest -v --tb native --ignore={[vars]tst_path}unit --log-cli-level=INFO -s {posargs}
+    pytest -v \
+           -s \
+           --tb native \
+           --ignore={[vars]tst_path}unit \
+           --ignore={[vars]tst_path}functional \
+           --log-cli-level=INFO
+           --model controller \
+           --keep-models \
+           {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,7 @@ envlist = lint, unit
 [vars]
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
-lib_path = {toxinidir}/lib/charms/slurmd
-all_path = {[vars]src_path} {[vars]tst_path} {[vars]lib_path} 
-lxd_name = slurmd-func-test
-ftest_path = {toxinidir}/tests/functional
+all_path = {[vars]src_path} {[vars]tst_path}
 
 [testenv]
 setenv =
@@ -40,8 +37,6 @@ deps =
     codespell==2.2.2
     ruff==0.0.206
 commands =
-    # uncomment the following line if this charm owns a lib
-    codespell {[vars]lib_path}
     codespell {toxinidir}/. \
     --skip {toxinidir}/.git \
     --skip {toxinidir}/.tox \
@@ -70,58 +65,3 @@ commands =
         -s \
         {posargs}
     coverage report
-
-[testenv:functional]
-description = Build a LXD container for functional tests then run the tests
-allowlist_externals = 
-    lxc
-    bash
-commands =
-    # Create a LXC container with the relevant packages installed
-    bash -c 'lxc launch -qe ubuntu:jammy {[vars]lxd_name} -c=user.user-data="$(<{[vars]ftest_path}/test_setup.yaml)"'
-    # Wait for the cloud-init process to finish
-    lxc exec {[vars]lxd_name} -- bash -c "cloud-init status -w >/dev/null 2>&1"
-    # Copy all the files needed for integration testing
-    lxc file push -qp {toxinidir}/tox.ini {[vars]lxd_name}/{[vars]lxd_name}/
-    lxc file push -qp {toxinidir}/pyproject.toml {[vars]lxd_name}/{[vars]lxd_name}/
-    lxc file push -qp {toxinidir}/config.yaml {[vars]lxd_name}/{[vars]lxd_name}/
-    lxc file push -qpr {toxinidir}/lib {[vars]lxd_name}/{[vars]lxd_name}/
-    lxc file push -qpr {toxinidir}/src {[vars]lxd_name}/{[vars]lxd_name}/
-    lxc file push -qpr {[vars]tst_path} {[vars]lxd_name}/{[vars]lxd_name}/
-    # Run the tests
-    lxc exec {[vars]lxd_name} -- tox -c /{[vars]lxd_name}/tox.ini -e functional-tests {posargs}
-commands_post =
-    -lxc stop {[vars]lxd_name}
-
-[testenv:functional-tests]
-description = Run functional tests
-deps =
-    ops==1.5.4
-    pytest==7.2.0
-commands =
-    pytest -v \
-           -s \
-           --tb native \
-           --ignore={[vars]tst_path}unit \
-           --ignore={[vars]tst_path}integration \
-           --log-cli-level=INFO \
-           {posargs}
-
-[testenv:integration]
-description = Run integration tests
-deps =
-    pytest==7.2.0
-    juju==3.0.4
-    pytest-operator==0.22.0
-    requests==2.28.1
-    tenacity==8.1.0
-commands =
-    pytest -v \
-           -s \
-           --tb native \
-           --ignore={[vars]tst_path}unit \
-           --ignore={[vars]tst_path}functional \
-           --log-cli-level=INFO
-           --model controller \
-           --keep-models \
-           {posargs}


### PR DESCRIPTION
Hey folks, similar to the initial PRs from last week this PR establishes the initial unit tests and CI pipeline for **slurmd-operator**. 

### Summary of Change

- Add initial templates for bug reports, enhancement requests, and pull requests
- Add a basic CI pipeline using GitHub actions
              - Inclusive language check
              - Lint
                  - A separate PR will cover linting changes, currently linting has not been run yet. Those changes will stem from the results of running `tox -e lint`.
              - Unit tests
- Formatting
              - Changes to the source code in this PR stem from running `tox -e fmt`. These changes result from using `black` and `ruff`.
- Unit Tests
              - These tests only test the typical expected behavior of the charm. Integration and functional tests will follow in later PRs however those are not covered here. 

Please take a look and ensure these changes are satisfactory and raise any questions, comments, or concerns!