### PR TITLE
bugfix: Update integration tests to use MySQL and MySQL router with slurmdbd

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
       - name: woke
         uses: get-woke/woke-action@v0
         with:
@@ -67,7 +66,6 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: lxd
-          # Juju channel should eventually be updated to 3.0/stable
-          juju-channel: 2.9/stable
+          juju-channel: 3.1/stable
       - name: Run tests
         run: tox -e integration

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright 2023 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tox.ini
+++ b/tox.ini
@@ -56,10 +56,9 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==3.0.4
+    juju==3.1.0.1
     pytest==7.2.0
     pytest-operator==0.22.0
-    tenacity==8.1.0
 commands =
     pytest -v \
            -s \


### PR DESCRIPTION
## Description

* Bumped CI pipeline to use Juju 3.1/stable.
* Updated integration tests to use MySQL and MySQL router operators over Percona XtraDB Cluster.
* Removed tenacity as a test dependency.

## How was the code tested?

I ran the new integration tests on my local LXD cloud using `tox -e integration`.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
