### PR TITLE
Add support for Ubuntu 22.04: part 1

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,8 +2,11 @@ type: charm
 bases:
   - build-on:
       - name: ubuntu
-        channel: "20.04"
+        channel: "22.04"
     run-on:
+      - name: ubuntu
+        channel: "22.04"
+        architectures: [amd64]
       - name: ubuntu
         channel: "20.04"
         architectures: [amd64]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,38 +1,29 @@
 name: slurmd
-
 summary: |
-    Slurmd, the compute node daemon of Slurm.
-
+  Slurmd, the compute node daemon of Slurm.
+description: |
+  This charm provides slurmd, munged, and the bindings to other utilities
+  that make lifecycle operations a breeze.
+  
+  slurmd is the compute node daemon of SLURM. It monitors all tasks running
+  on the compute node, accepts work (tasks), launches tasks, and kills
+  running tasks upon request.
+source: https://github.com/omnivector-solutions/slurmd-operator
+issues: https://github.com/omnivector-solutions/slurmd-operator/issues
 maintainers:
     - OmniVector Solutions <admin@omnivector.solutions>
-
-description: |
-    This charm provides slurmd, munged, and the bindings to other utilities
-    that make lifecycle operations a breeze.
-
-    slurmd is the compute node daemon of SLURM. It monitors all tasks running
-    on the compute node, accepts work (tasks), launches tasks, and kills
-    running tasks upon request.
-
-tags:
-    - slurm
-    - hpc
-
-series:
-    - focal
-    - centos7
-
-provides:
-  slurmd:
-    interface: slurmd
-
-requires:
-  fluentbit:
-    interface: fluentbit
+    - Jason C. Nucciarone <jason.nucciarone@canonical.com>
+    - David Gomez <david.gomez@canonical.com>
 
 peers:
   slurmd-peer:
     interface: slurmd-peer
+requires:
+  fluentbit:
+    interface: fluentbit
+provides:
+  slurmd:
+    interface: slurmd
 
 resources:
   nhc:
@@ -40,3 +31,6 @@ resources:
      filename: lbnl-nhc-1.4.3.tar.gz
      description: |
        Official tarball containing NHC. Retrieved from Github Releases.
+
+assumes:
+  - juju


### PR DESCRIPTION
## Description

Hey folks! This is part 1 of my work to upgrade the slurmd-operator to support Ubuntu 22.04 (Jammy Jellyfish) as a base. This pull request mostly just contains metadata updates so that Juju does not fail when deploying slurmd-operator to a 22.04 machine. Part 2 will contain the relevant integration test and CI pipeline updates. This pull request is mostly intended to make it so that I can pull "Jammified" SLURM charms from Charmhub for the integration tests.

Here are a couple of things that I changed in this pull request.

- Added me and David as maintainers in `metadata.yaml`. I felt that it would be good for us to be listed in maintainers so third-parties know who to contact about Canonical-licensed bits of code.
- Organized sections in `metadata.yaml`.
  - `tags` and `series` [are not supported options](https://juju.is/docs/sdk/metadata-yaml).  
- Added links for finding source code and issue tracker.
- Added assumes Juju so the charm is not accidentally deployed to a k8s charm.
- Added Ubuntu 22.04 to the `runs-on` section of `charmcraft.yaml`. Since slurmd does not bundle platform-specific, dynamic binaries in the charm, we shouldn't need to have a separate builds on step too. NHC is mostly written in shell if I am not mistaken.

## How was the code tested?

I tested the code manually on my local machine due to Ubuntu 22.04 charms not being currently published to the edge channel on Charmhub.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
