### PR TITLE
bugfix: Use `ubuntu-latest` instead of `20.04`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Release to CharmHub
     needs:
       - ci-tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

Really simple, just bumping the version of Ubuntu used for the CI pipeline.
