### PR TITLE
Drop needs_reboot conditional in `_check_status(...)`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ __pycache__/
 *.py[cod]
 .idea
 .vscode/
+version

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,7 +6,6 @@
 
 import json
 import logging
-import subprocess
 from pathlib import Path
 from time import sleep
 
@@ -17,7 +16,7 @@ from omnietcd3 import Etcd3AuthClient
 from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, EventSource, StoredState
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from slurm_ops_manager import SlurmManager
 
 logger = logging.getLogger()
@@ -146,15 +145,6 @@ class SlurmdCharm(CharmBase):
         - slurmctld available and working
         - munge key configured and working
         """
-        if self._slurm_manager.needs_reboot:
-            try:
-                self.unit.status = MaintenanceStatus("Rebooting...")
-                logger.debug("Scheduling machine reboot")
-                subprocess.run(["juju-reboot"], check=True)
-            except subprocess.CalledProcessError:
-                logger.error("Failed to schedule machine reboot")
-            return False
-
         if not self.get_partition_name():
             self.unit.status = WaitingStatus("Waiting on charm configuration")
             return False

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -19,7 +19,7 @@ import unittest
 from unittest.mock import PropertyMock, patch
 
 from charm import SlurmdCharm
-from ops.model import ActiveStatus, BlockedStatus
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.testing import Harness
 
 
@@ -123,10 +123,11 @@ class TestCharm(unittest.TestCase):
     @patch(
         "slurm_ops_manager.SlurmManager.needs_reboot", new_callable=PropertyMock(return_value=True)
     )
-    def test_update_status_needs_reboot(self, _) -> None:
+    @patch("subprocess.run")
+    def test_update_status_needs_reboot(self, *_) -> None:
         """Test update_status failure behavior from reboot."""
         self.harness.charm.on.update_status.emit()
-        self.assertEqual(self.harness.charm.unit.status, BlockedStatus("Machine needs reboot"))
+        self.assertEqual(self.harness.charm.unit.status, MaintenanceStatus("Rebooting..."))
 
     @patch(
         "slurm_ops_manager.SlurmManager.needs_reboot",


### PR DESCRIPTION
## Description

This pull request adds `juju-reboot` to the `_check_status(...)` function so that the machine will automatically restart if it needs security updates applied. Using `juju-reboot` helps with automatic deployments as a human-operator is not required to manually intervene when the slurmd charm is first deployed.

## How was the code tested?

I tested this charm on a private OpenStack instance with ubuntu@22.04 base images that needed security updates to be deployed.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
