### PR TITLE
Add support for Ubuntu 22.04: part 2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,13 @@ jobs:
         run: tox -e unit
 
   integration-test:
-    name: Integration tests (LXD)
+    strategy:
+      fail-fast: true
+      matrix:
+        bases:
+          - ubuntu@20.04
+          - ubuntu@22.04
+    name: Integration tests (LXD) | ${{ matrix.bases }}
     runs-on: ubuntu-latest
     needs:
       - inclusive-naming-check
@@ -68,4 +74,4 @@ jobs:
           provider: lxd
           juju-channel: 3.1/stable
       - name: Run tests
-        run: tox -e integration
+        run: tox run -e integration -- --charm-base=${{ matrix.bases }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,9 @@ extend-ignore = [
     "D409",
     "D413",
 ]
-ignore = ["E501"]
+ignore = ["E501", "D107"]
 extend-exclude = ["__pycache__", "*.egg_info"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.ruff.mccabe]
 max-complexity = 10

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -17,12 +17,25 @@
 
 import pathlib
 
+import pytest
+from _pytest.config.argparsing import Parser
 from helpers import ETCD, NHC, VERSION
-from pytest import fixture
 from pytest_operator.plugin import OpsTest
 
 
-@fixture(scope="module")
+def pytest_addoption(parser: Parser) -> None:
+    parser.addoption(
+        "--charm-base", action="store", default="ubuntu@22.04", help="Charm base to test."
+    )
+
+
+@pytest.fixture(scope="module")
+def charm_base(request) -> str:
+    """Get slurmdbd charm base to use."""
+    return request.config.getoption("--charm-base")
+
+
+@pytest.fixture(scope="module")
 async def slurmd_charm(ops_test: OpsTest):
     """Build slurmd charm to use for integration tests."""
     charm = await ops_test.build_charm(".")

--- a/tox.ini
+++ b/tox.ini
@@ -57,14 +57,16 @@ commands =
 description = Run integration tests
 deps =
     juju==3.1.0.1
+    pylxd==2.3.1
     pytest==7.2.0
-    pytest-operator==0.22.0
+    pytest-operator==0.26.0
+    pytest-order==1.1.0
+    tenacity==8.2.2
+    -r{toxinidir}/requirements.txt
 commands =
     pytest -v \
-           -s \
-           --tb native \
-           --ignore={[vars]tst_path}unit \
-           --log-cli-level=INFO \
-           --model controller \
-           --keep-models \
-           {posargs}
+        -s \
+        --tb native \
+        --log-cli-level=INFO \
+        {[vars]tst_path}integration \
+        {posargs}


### PR DESCRIPTION
## Description

This pull request adds integration tests for Jammy. It also adds a CI matrix to the GitHub Actions pipeline so we can test both Focal and Jammy at the same time. Also, this pull request modifies the integration tests so that the default LXD profile is modified before the charmed operators are deployed. This modification is needed for slurmd to work inside of the LXD container.

## How was the code tested?

I ran the integration tests on my local workstation with LXD cloud.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
