### PR TITLE
Fix README.md text

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A [Juju](https://juju.is) operator for slurmd - the compute node daemon of [SLUR
 
 ## Features
 
-The slurmd operator provides and manages the slurmd daemon. This operator provides the compute node service for virtual machines enlisted as compute nodes in Charmed SLURM clusters.
+The slurmd operator provides and manages the slurmd daemon. This operator provides the compute node service for machines enlisted as compute nodes in Charmed SLURM clusters.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A [Juju](https://juju.is) operator for slurmd - the compute node daemon of [SLUR
 
 ## Features
 
-The slurmctld operator provides and manages the slurmd daemon. This operator provides the compute node service for virtual machines enlisted as compute nodes in Charmed SLURM clusters.
+The slurmd operator provides and manages the slurmd daemon. This operator provides the compute node service for virtual machines enlisted as compute nodes in Charmed SLURM clusters.
 
 ## Usage
 


### PR DESCRIPTION
## Description

Update README.md text fixing a mismatched operator name.

`slurmctld` operator should be `slurmd` operator on https://github.com/omnivector-solutions/slurmd-operator#features

## How was the code tested?

No test is needed.

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
