### PR TITLE
Auto-generate version file when slurmd operator is packed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,8 +31,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Create version file
-        run: git describe --tags --always --dirty > version
       - name: Select charmhub channel
         uses: canonical/charming-actions/channel@2.2.0
         id: channel

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -21,3 +21,17 @@ parts:
   charm:
     build-packages: [git]
     charm-python-packages: [setuptools]
+
+  # Create a version file and pack it into the charm. This is dynamically generated
+  # as part of the build process for a charm to ensure that the git revision of the
+  # charm is always recorded in this version file.
+  version-file:
+    plugin: nil
+    build-packages:
+      - git
+    override-build: |
+      VERSION=$(git -C $CRAFT_PART_SRC/../../charm/src describe --dirty --always)
+      echo "Setting version to $VERSION"
+      echo $VERSION > $CRAFT_PART_INSTALL/version
+    stage:
+      - version

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -18,7 +18,7 @@
 from pathlib import Path
 
 import pytest
-from helpers import NHC, VERSION
+from helpers import NHC
 from pytest_operator.plugin import OpsTest
 
 
@@ -43,4 +43,3 @@ async def slurmd_charm(ops_test: OpsTest):
 def pytest_sessionfinish(session, exitstatus) -> None:
     """Clean up repository after test session has completed."""
     Path(NHC).unlink(missing_ok=True)
-    Path(VERSION).unlink(missing_ok=True)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -16,7 +16,6 @@
 
 import logging
 import pathlib
-import subprocess
 from typing import Dict
 from urllib import request
 
@@ -24,17 +23,10 @@ logger = logging.getLogger(__name__)
 
 NHC = "lbnl-nhc-1.4.3.tar.gz"
 NHC_URL = f"https://github.com/mej/nhc/releases/download/1.4.3/{NHC}"
-VERSION = "version"
-VERSION_NUM = subprocess.run(
-    ["git", "describe", "--always"], stdout=subprocess.PIPE, text=True
-).stdout.strip("\n")
 
 
 def get_slurmd_res() -> Dict[str, pathlib.Path]:
     """Get slurmd resources needed for charm deployment."""
-    if not (version := pathlib.Path(VERSION)).exists():
-        logger.info(f"Setting resource {VERSION} to value {VERSION_NUM}")
-        version.write_text(VERSION_NUM)
     if not (nhc := pathlib.Path(NHC)).exists():
         logger.info(f"Getting resource {NHC} from {NHC_URL}")
         request.urlretrieve(NHC_URL, nhc)


### PR DESCRIPTION
Similar to pull request https://github.com/omnivector-solutions/slurmdbd-operator/pull/16

Modifies `charmcraft.yaml` so that the version file is automatically generated when the slurmd operator is packed by charmcraft. This pull request is coming after the etcd removal pull request because there would have been some merge conflicts due to changes made to the integration tests.