### PR TITLE
Check symlink exists prior to creating symlinks

### DIFF
--- a/lib/charms/hpc_libs/v0/juju_systemd_notices.py
+++ b/lib/charms/hpc_libs/v0/juju_systemd_notices.py
@@ -110,8 +110,10 @@ class SystemdNotices:
         """Subscribe charmed operator to observe status of systemd services."""
         _logger.debug(f"Generating systemd notice hooks for {self._services}")
         for service in self._services:
-            Path(f"hooks/service-{service}-started").symlink_to(f"{Path.cwd()}/dispatch")
-            Path(f"hooks/service-{service}-stopped").symlink_to(f"{Path.cwd()}/dispatch")
+            for hook in {"started", "stopped"}:
+                hook = Path(f"hooks/service-{service}-{hook}")
+                if not hook.exists():
+                    hook.symlink_to(f"{Path.cwd()}/dispatch")
 
         _logger.debug(f"Starting {self._service_file.name} daemon")
         if self._service_file.exists():


### PR DESCRIPTION
## Description

If the target service-{service}-[started|stopped] hook already exists then the pathlib.Path.symlink_to() will fail when setting up the custom hooks for the juju_systemd_notices daemon. The library should handle this better by first checking the existence of the target path prior to attempting to create the symlink.

## How was the code tested?

`tox -e unit,integration`

Substrate: LXD
Operating Systems:
- [X] Ubuntu 20.04
- [X] Ubuntu 22.04
- [ ] CentOS 7

## Related issues and/or tasks

Related to change in [PR#21](https://github.com/omnivector-solutions/slurmd-operator/pull/21)

## Checklist

- [X] I am the author of these changes, or I have the rights to submit them.
- [X] I have added the relevant changes to the README and/or documentation.
- [X] I have self reviewed my own code.
- [x] All requested changes and/or review comments have been resolved.
