### PR TITLE
Add support for using local charms in integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -13,31 +13,87 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Configure integration test run."""
+"""Configure slurmd operator integration tests."""
 
+import logging
+import os
 from pathlib import Path
+from typing import Union
 
 import pytest
 from helpers import NHC
 from pytest_operator.plugin import OpsTest
 
+logger = logging.getLogger(__name__)
+SLURMCTLD_DIR = Path(os.getenv("SLURMCTLD_DIR", "../slurmctld-operator"))
+SLURMDBD_DIR = Path(os.getenv("SLURMDBD_DIR", "../slurmdbd-operator"))
+
 
 def pytest_addoption(parser) -> None:
     parser.addoption(
-        "--charm-base", action="store", default="ubuntu@22.04", help="Charm base to test."
+        "--charm-base",
+        action="store",
+        default="ubuntu@22.04",
+        help="Charm base version to use for integration tests.",
+    )
+    parser.addoption(
+        "--use-local",
+        action="store_true",
+        default=False,
+        help="Use SLURM operators located on localhost rather than pull from Charmhub",
     )
 
 
 @pytest.fixture(scope="module")
 def charm_base(request) -> str:
     """Get slurmd charm base to use."""
-    return request.config.getoption("--charm-base")
+    return request.config.option.charm_base
 
 
 @pytest.fixture(scope="module")
-async def slurmd_charm(ops_test: OpsTest):
-    """Build slurmd charm to use for integration tests."""
+async def slurmd_charm(ops_test: OpsTest) -> Path:
+    """Pack slurmd charm to use for integration tests."""
     return await ops_test.build_charm(".")
+
+
+@pytest.fixture(scope="module")
+async def slurmctld_charm(request, ops_test: OpsTest) -> Union[str, Path]:
+    """Pack slurmctld charm to use for integration tests when --use-local is specified.
+
+    Returns:
+        `str` "slurmctld" if --use-local not specified or if SLURMD_DIR does not exist.
+    """
+    if request.config.option.use_local:
+        logger.info("Using local slurmctld operator rather than pulling from Charmhub")
+        if SLURMCTLD_DIR.exists():
+            return await ops_test.build_charm(SLURMCTLD_DIR)
+        else:
+            logger.warning(
+                f"{SLURMCTLD_DIR} not found. "
+                f"Defaulting to latest/edge slurmctld operator from Charmhub"
+            )
+
+    return "slurmctld"
+
+
+@pytest.fixture(scope="module")
+async def slurmdbd_charm(request, ops_test: OpsTest) -> Union[str, Path]:
+    """Pack slurmdbd charm to use for integration tests when --use-local is specified.
+
+    Returns:
+        `str` "slurmdbd" if --use-local not specified or if SLURMDBD_DIR does not exist.
+    """
+    if request.config.option.use_local:
+        logger.info("Using local slurmdbd operator rather than pulling from Charmhub")
+        if SLURMDBD_DIR.exists():
+            return await ops_test.build_charm(SLURMDBD_DIR)
+        else:
+            logger.warning(
+                f"{SLURMDBD_DIR} not found. "
+                f"Defaulting to latest/edge slurmdbd operator from Charmhub"
+            )
+
+    return "slurmdbd"
 
 
 def pytest_sessionfinish(session, exitstatus) -> None:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -15,7 +15,7 @@
 """Helpers for the slurmd integration tests."""
 
 import logging
-import pathlib
+from pathlib import Path
 from typing import Dict
 from urllib import request
 
@@ -25,9 +25,9 @@ NHC = "lbnl-nhc-1.4.3.tar.gz"
 NHC_URL = f"https://github.com/mej/nhc/releases/download/1.4.3/{NHC}"
 
 
-def get_slurmd_res() -> Dict[str, pathlib.Path]:
+async def get_slurmd_res() -> Dict[str, Path]:
     """Get slurmd resources needed for charm deployment."""
-    if not (nhc := pathlib.Path(NHC)).exists():
+    if not (nhc := Path(NHC)).exists():
         logger.info(f"Getting resource {NHC} from {NHC_URL}")
         request.urlretrieve(NHC_URL, nhc)
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ passenv =
     PYTHONPATH
     CHARM_BUILD_DIR
     MODEL_SETTINGS
+    SLURMCTLD_DIR
+    SLURMDBD_DIR
 
 [testenv:fmt]
 description = Apply coding style standards to code
@@ -57,8 +59,7 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju==3.1.0.1
-    pylxd==2.3.1
+    juju
     pytest==7.2.0
     pytest-operator==0.26.0
     pytest-order==1.1.0


### PR DESCRIPTION
## Description

Similar to https://github.com/omnivector-solutions/slurmctld-operator/pull/17, but slurmd focused :sweat_smile: 

## How was the code tested?

Integration tests were run on my Ubuntu 23.04 laptop.

## Related issues and/or tasks

Closes #23 

## Checklist

- [x] I am the author of these changes, or I have the rights to submit them.
- [x] I have added the relevant changes to the README and/or documentation.
- [x] I have self reviewed my own code.
- [ ] All requested changes and/or review comments have been resolved.
